### PR TITLE
Enable usage with @playwright/test

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ Add `Jest-Sinon` to your Jest `setupFilesAfterEnv` configuration.
 require('jest-sinon');
 ```
 
+### @playwright/test
+
+```js
+const assertions = require('jest-sinon/assertions');
+// Or
+import * as assertions from 'jest-sinon/assertions';
+
+expect.extend(assertions);
+```
+
 ## Usage
 
 `Jest-Sinon` adds a number of assertions to help test `Sinon.js` Spies, Mocks and Stubs. Below is a list of currently implemented assertions.

--- a/package.json
+++ b/package.json
@@ -2,8 +2,18 @@
   "name": "jest-sinon",
   "version": "1.1.0",
   "description": "Jest assertions for the mocking library Sinon.js",
-  "main": "dist/jest-sinon.cjs.js",
-  "module": "dist/jest-sinon.esm.js",
+  "main": "./dist/cjs/jest-sinon.js",
+  "module": "./dist/esm/jest-sinon.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/jest-sinon.mjs",
+      "require": "./dist/cjs/jest-sinon.js"
+    },
+    "./assertions": {
+      "import": "./dist/esm/assertions.mjs",
+      "require": "./dist/cjs/assertions.js"
+    }
+  },
   "license": "MIT",
   "keywords": [
     "jest",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,24 +1,26 @@
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import babel from 'rollup-plugin-babel';
-import pkg from './package.json';
 
 export default [
   {
-    input: 'src/index.js',
-    external: [
-      'jest-matcher-utils'
-    ],
+    input: { 'jest-sinon': 'src/index.js', 'assertions': 'src/assertions/index.js' },
+    external: ['jest-matcher-utils'],
     plugins: [
       resolve(),
       commonjs(),
       babel({
         exclude: ['node_modules/**']
-      }),
+      })
     ],
     output: [
-      { file: pkg.main, format: 'cjs' },
-      { file: pkg.module, format: 'es' }
+      { dir: 'dist/cjs', format: 'cjs' },
+      {
+        dir: 'dist/esm',
+        format: 'es',
+        entryFileNames: '[name].mjs',
+        chunkFileNames: '[name]-[hash].mjs'
+      }
     ]
   }
 ];


### PR DESCRIPTION
I only tested using it with @playwright/test, not sure if there are further adjustments needed for Vitest as it has it's own spies and matchers for them

See #32